### PR TITLE
strip BOM code of UTF-8

### DIFF
--- a/db/activiti-prereq.sql
+++ b/db/activiti-prereq.sql
@@ -1,4 +1,4 @@
-﻿--DROP ROLE activiti;
+--DROP ROLE activiti;
 
 CREATE ROLE activiti LOGIN
 ENCRYPTED PASSWORD 'md529396e43ae92947c301a806c535bb7b9'

--- a/db/kloopzcm-partition.ddl
+++ b/db/kloopzcm-partition.ddl
@@ -1,4 +1,4 @@
-﻿
+
 
 CREATE TABLE kloopzcm.cm_ci_relation_attr_log_2012 (
 		CHECK ( log_time >= DATE '2012-01-01' AND log_time < DATE '2013-01-01' )

--- a/db/kloopzcm-postprocess.sql
+++ b/db/kloopzcm-postprocess.sql
@@ -1,4 +1,4 @@
-﻿CREATE SEQUENCE kloopzcm.md_pk_seq
+CREATE SEQUENCE kloopzcm.md_pk_seq
    INCREMENT 1
    START 1000;
 ALTER TABLE kloopzcm.md_pk_seq OWNER TO kloopzcm;


### PR DESCRIPTION
These three files have "BOM" (byte order mark) and caused error at psql command execution during provision.
I found this error at CentOS-6.7 box. (/w Vagrant)

This pull requests get rid of these BOM.
