### PR TITLE
Updated shell to bash for compat

### DIFF
--- a/db/autoinstall-db.sh
+++ b/db/autoinstall-db.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 # xargs to trim

--- a/db/install-db.sh
+++ b/db/install-db.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # change PSQL if needed
 INSTALLED_PSQL=`which psql`

--- a/db/single_db_install.sh
+++ b/db/single_db_install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export PSQL=psql
 


### PR DESCRIPTION
While setting up a dev environment for OneOps on an Ubuntu machine I noticed that I was getting errors in some of these scripts. This is because some of the commands and options used (e.g. read -n) do not work on Ubuntu as invoking "sh" executes the dash shell where these options are not allowed. Please use bash instead.